### PR TITLE
feat: add long-press to copy functionality to UserInfoTile

### DIFF
--- a/lib/core/common/widget/user_info_tile.dart
+++ b/lib/core/common/widget/user_info_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class UserInfoTile extends StatelessWidget {
   final String title;
@@ -13,24 +14,41 @@ class UserInfoTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            color: Theme.of(context).colorScheme.primary,
+    final displayDescription = description == '' ? 'N/A' : description;
+
+    return GestureDetector(
+      onLongPress: () async {
+        if (displayDescription != 'N/A') {
+          await Clipboard.setData(ClipboardData(text: displayDescription));
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('$title copied to clipboard'),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+          }
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.primary,
+            ),
           ),
-        ),
-        const SizedBox(height: 0),
-        Text(
-          description == '' ? 'N/A' : description,
-          style: Theme.of(context).textTheme.bodyLarge,
-        ),
-        SizedBox(height: gap)
-      ],
+          const SizedBox(height: 0),
+          Text(
+            displayDescription,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          SizedBox(height: gap)
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Description

Closes #40 

- Adds long-press to copy functionality to the UserInfoTile widget.
- Makes it easier to quickly copy profile details like a mentor's cabin number, email, or phone number instead of having to type them out manually.
- Updates both the You (Personal Profile) page and the Mentor page globally since they share this component
- Copies the text directly to the clipboard on hold and displays a simple snackbar to show it worked.

## Changes Made

- lib/core/common/widget/user_info_tile.dart:
- Wrapped the card layout in a GestureDetector to catch onLongPress
- Added Clipboard.setData to copy the text field value
- Added a SnackBar for visual feedback when successfully copied.


## Screenshots / Recording

<!-- Required for any UI change. Drag and drop here. Delete this section if not applicable. -->

<img width="747" height="1600" alt="vitapst_updtimg" src="https://github.com/user-attachments/assets/fd9ece39-d372-470a-9c5d-c5a1d6b63d06" />


## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [ ] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [ ] `cargo fmt` run inside `rust/`
- [ ] `cargo clippy` passes with no new warnings inside `rust/`
- [ ] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [x] Existing features unaffected by this change
