### PR TITLE
feat(user_info_tile): add long press to copy description to clipboard

### DIFF
--- a/lib/core/common/widget/user_info_tile.dart
+++ b/lib/core/common/widget/user_info_tile.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../utils/show_snackbar.dart';
 
 class UserInfoTile extends StatelessWidget {
   final String title;
@@ -13,24 +15,39 @@ class UserInfoTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            color: Theme.of(context).colorScheme.primary,
+    final displayDescription = description == '' ? 'N/A' : description;
+    return GestureDetector(
+      onLongPress: () async {
+        if (displayDescription != 'N/A') {
+          await Clipboard.setData(ClipboardData(text: displayDescription));
+          if (context.mounted) {
+            showSnackBar(
+              context,
+              '$title copied to clipboard',
+              SnackBarType.success,
+            );
+          }
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.primary,
+            ),
           ),
-        ),
-        const SizedBox(height: 0),
-        Text(
-          description == '' ? 'N/A' : description,
-          style: Theme.of(context).textTheme.bodyLarge,
-        ),
-        SizedBox(height: gap)
-      ],
+          const SizedBox(height: 0),
+          Text(
+            displayDescription,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          SizedBox(height: gap),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] test — adding or updating tests
- [ ] docs — documentation only
- [ ] rust — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #40

## Description

This PR adds a long-press copy interaction to the user info tile so users can quickly copy field values to the clipboard.  
When the value is available, the app copies it and shows a success snackbar using the shared snackbar utility.

## Changes Made

- Added long-press handling on the user info tile.
- Added clipboard copy support for non-empty values.
- Added display-value normalization (`N/A`) and avoided copying placeholder values.
- Replaced inline snackbar usage with the shared `showSnackBar` helper (`SnackBarType.success`).

## Checklist

### Flutter

- [ ] `flutter analyze` passes with no new warnings
- [ ] `flutter test` passes
- [ ] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [ ] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [ ] `cargo fmt` run inside `rust/`
- [ ] `cargo clippy` passes with no new warnings inside `rust/`
- [ ] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [ ] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [x] Existing features unaffected by this change
