### PR TITLE
fix: correct payment receipt parser for vtop's new column layout

### DIFF
--- a/rust/src/api/vtop/client/payment.rs
+++ b/rust/src/api/vtop/client/payment.rs
@@ -41,18 +41,20 @@ impl VtopClient {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
+    /// # use lib_vtop::api::vtop::vtop_client::VtopClient;
     /// # async fn example(client: &mut VtopClient) -> Result<(), Box<dyn std::error::Error>> {
-    /// // First get the list of receipts
+    /// // First get the list of receipts, and the application number from the profile.
     /// let receipts = client.get_payment_receipts().await?;
+    /// let profile = client.get_student_profile().await?;
     ///
     /// // Download a specific receipt
     /// if let Some(receipt) = receipts.first() {
     ///     let receipt_html = client.download_payment_receipt(
     ///         receipt.receipt_no.clone(),
-    ///         receipt.applno.clone()
+    ///         profile.application_number.clone(),
     ///     ).await?;
-    ///     
+    ///
     ///     // Save to file or display
     ///     std::fs::write("payment_receipt.html", receipt_html)?;
     ///     println!("Receipt downloaded successfully");
@@ -124,7 +126,8 @@ impl VtopClient {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
+    /// # use lib_vtop::api::vtop::vtop_client::VtopClient;
     /// # async fn example(client: &mut VtopClient) -> Result<(), Box<dyn std::error::Error>> {
     /// let receipts = client.get_payment_receipts().await?;
     ///
@@ -133,13 +136,13 @@ impl VtopClient {
     ///     println!("Receipt: {} | Amount: ₹{} | Date: {}",
     ///         receipt.receipt_no,
     ///         receipt.amount,
-    ///         receipt.payment_date
+    ///         receipt.date
     ///     );
     /// }
     ///
-    /// // Calculate total paid
+    /// // Calculate total paid (amounts are strings, so parse them)
     /// let total: f64 = receipts.iter()
-    ///     .map(|r| r.amount)
+    ///     .filter_map(|r| r.amount.parse::<f64>().ok())
     ///     .sum();
     /// println!("Total paid: ₹{}", total);
     /// # Ok(())
@@ -203,7 +206,8 @@ impl VtopClient {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
+    /// # use lib_vtop::api::vtop::vtop_client::VtopClient;
     /// # async fn example(client: &mut VtopClient) -> Result<(), Box<dyn std::error::Error>> {
     /// let pending = client.get_pending_payment().await?;
     ///
@@ -211,18 +215,18 @@ impl VtopClient {
     ///     println!("No pending payments - all clear!");
     /// } else {
     ///     println!("You have {} pending payment(s):", pending.len());
-    ///     
+    ///
     ///     for payment in &pending {
     ///         println!("- {} | Amount: ₹{} | Due: {}",
-    ///             payment.description,
-    ///             payment.amount,
-    ///             payment.due_date
+    ///             payment.fees_heads,
+    ///             payment.total_amount,
+    ///             payment.end_date
     ///         );
     ///     }
-    ///     
-    ///     // Calculate total due
+    ///
+    ///     // Calculate total due (amounts are strings, so parse them)
     ///     let total_due: f64 = pending.iter()
-    ///         .map(|p| p.amount)
+    ///         .filter_map(|p| p.total_amount.parse::<f64>().ok())
     ///         .sum();
     ///     println!("\nTotal amount due: ₹{}", total_due);
     /// }
@@ -230,16 +234,17 @@ impl VtopClient {
     /// # }
     /// ```
     ///
-    /// ```
+    /// ```no_run
+    /// # use lib_vtop::api::vtop::vtop_client::VtopClient;
     /// # async fn example2(client: &mut VtopClient) -> Result<(), Box<dyn std::error::Error>> {
-    /// // Check for overdue payments
+    /// // List the pending payments that carry a fine.
     /// let pending = client.get_pending_payment().await?;
-    /// let overdue: Vec<_> = pending.iter()
-    ///     .filter(|p| p.status == "Overdue")
+    /// let with_fine: Vec<_> = pending.iter()
+    ///     .filter(|p| p.fine != "0" && !p.fine.is_empty())
     ///     .collect();
-    ///     
-    /// if !overdue.is_empty() {
-    ///     println!("URGENT: {} overdue payment(s) require immediate attention!", overdue.len());
+    ///
+    /// if !with_fine.is_empty() {
+    ///     println!("URGENT: {} payment(s) have accrued a fine!", with_fine.len());
     /// }
     /// # Ok(())
     /// # }

--- a/rust/src/api/vtop/parser/payment_receipts_parser.rs
+++ b/rust/src/api/vtop/parser/payment_receipts_parser.rs
@@ -1,79 +1,131 @@
 use crate::api::vtop::types::paid_payment_receipt::PaidPaymentReceipt;
-use scraper::{Html, Selector};
+use scraper::{ElementRef, Html, Selector};
+use std::collections::HashMap;
 
-/// Parses an HTML string to extract payment receipt information from a table.
+/// Parses an HTML string to extract paid payment receipts from the receipts table.
 ///
-/// Searches for the first table with the class `table table-bordered` in the provided HTML,
-/// then iterates over its rows (excluding the header) to extract receipt details. For each row
-/// with at least five columns, it collects the receipt number, date, amount, campus code, and
-/// attempts to parse the receipt number from a button's `onclick` attribute. Each parsed row
-/// is converted into a `PaymentReceipt` with a fixed payment status of "Paid".
+/// Columns are located by their **header label** rather than a fixed position,
+/// because VTOP has reordered and inserted columns in this table over time
+/// (invoice number, fee group and fee subgroup now sit between the receipt
+/// number and the amount). Positional fallbacks keep it working if the headers
+/// ever change again.
+///
+/// The receipt number needed for the duplicate-receipt download lives in the
+/// row's view button, which is located by its `doDuplicateReceipt(...)` handler
+/// rather than a fixed cell. Rows without such a button (totals or empty-state
+/// rows) are skipped rather than treated as receipts.
 ///
 /// # Returns
-/// A vector of `PaymentReceipt` structs containing the extracted data. Rows missing required
-/// fields or elements are skipped.
+/// A vector of `PaidPaymentReceipt` structs, one per receipt row.
 ///
 /// # Examples
 ///
 /// ```
 /// let html = r#"
 /// <table class="table table-bordered">
-///   <tr><th>Receipt No</th><th>Date</th><th>Amount</th><th>Campus</th><th>Action</th></tr>
 ///   <tr>
-///     <td>12345</td><td>2024-01-01</td><td>1000</td><td>ABC</td>
-///     <td><button onclick="javascript:doDuplicateReceipt('12345/2024/ABC');"></button></td>
+///     <th>RECEIPT NUMBER</th><th>DATE</th><th>INVOICE NUMBER</th>
+///     <th>FEE GROUP</th><th>FEE SUBGROUP</th><th>AMOUNT</th>
+///     <th>CAMPUS CODE</th><th>VIEW</th>
+///   </tr>
+///   <tr>
+///     <td>78323</td><td>08-JUL-2026</td><td>AM2600123276</td>
+///     <td>HOSTEL FEE</td><td>Hostelfee</td><td>199300.0</td><td>AMR</td>
+///     <td><button onclick="javascript:doDuplicateReceipt('78323/27/AMR');"></button></td>
 ///   </tr>
 /// </table>
 /// "#.to_string();
-/// let receipts = parse_payment_receipts(html);
+/// let receipts = lib_vtop::api::vtop::parser::payment_receipts_parser::parse_payment_receipts(html);
 /// assert_eq!(receipts.len(), 1);
-/// assert_eq!(receipts[0].receipt_number, "12345");
-/// assert_eq!(receipts[0].receipt_no, "12345/2024/ABC");
+/// assert_eq!(receipts[0].receipt_number, "78323");
+/// assert_eq!(receipts[0].amount, "199300.0");
+/// assert_eq!(receipts[0].campus_code, "AMR");
+/// assert_eq!(receipts[0].receipt_no, "78323/27/AMR");
 /// ```
 pub fn parse_payment_receipts(html: String) -> Vec<PaidPaymentReceipt> {
     let doc = Html::parse_document(&html);
     let mut results = Vec::new();
 
-    // Find the main receipts table
     let table_selector = Selector::parse("table.table.table-bordered").unwrap();
-    if let Some(table) = doc.select(&table_selector).next() {
-        let row_selector = Selector::parse("tr").unwrap();
-        for row in table.select(&row_selector).skip(1) {
-            // skip header
-            let tds: Vec<_> = row.select(&Selector::parse("td").unwrap()).collect();
-            if tds.len() >= 5 {
-                let receipt_number = tds[0].text().collect::<String>().trim().to_string();
-                let date = tds[1].text().collect::<String>().trim().to_string();
-                let amount = tds[2].text().collect::<String>().trim().to_string();
-                let campus_code = tds[3].text().collect::<String>().trim().to_string();
+    let row_selector = Selector::parse("tr").unwrap();
+    let header_cell_selector = Selector::parse("td, th").unwrap();
+    let td_selector = Selector::parse("td").unwrap();
+    let button_selector = Selector::parse("button").unwrap();
 
-                // Extract receipt_no from button's onclick
-                let mut receipt_no = String::new();
-                if let Some(button) = tds[4].select(&Selector::parse("button").unwrap()).next() {
-                    if let Some(onclick) = button.value().attr("onclick") {
-                        // Example: javascript:doDuplicateReceipt('27640/26/AMR');
-                        let prefix = "doDuplicateReceipt('";
-                        let suffix = "')";
-                        if let Some(start) = onclick.find(prefix) {
-                            let rest = &onclick[start + prefix.len()..];
-                            if let Some(end) = rest.find(suffix) {
-                                receipt_no = rest[..end].to_string();
-                            }
-                        }
-                    }
+    let table = match doc.select(&table_selector).next() {
+        Some(t) => t,
+        None => return results,
+    };
+
+    let rows: Vec<_> = table.select(&row_selector).collect();
+    if rows.is_empty() {
+        return results;
+    }
+
+    // Map header labels (upper-cased) to their column positions.
+    let mut header_index: HashMap<String, usize> = HashMap::new();
+    for (i, cell) in rows[0].select(&header_cell_selector).enumerate() {
+        let label = cell.text().collect::<String>().trim().to_uppercase();
+        header_index.insert(label, i);
+    }
+    // Fallbacks are the *current* live positions, so an unrecognised header set
+    // still reads the right columns rather than the old (pre-change) ones.
+    let idx = |name: &str, default: usize| *header_index.get(name).unwrap_or(&default);
+    let i_receipt = idx("RECEIPT NUMBER", 0);
+    let i_date = idx("DATE", 1);
+    let i_amount = idx("AMOUNT", 5);
+    let i_campus = idx("CAMPUS CODE", 6);
+
+    for row in rows.iter().skip(1) {
+        let tds: Vec<_> = row.select(&td_selector).collect();
+        if tds.len() < 5 {
+            continue;
+        }
+
+        // Find the duplicate-receipt button anywhere in the row.
+        let mut receipt_no = String::new();
+        for button in row.select(&button_selector) {
+            if let Some(onclick) = button.value().attr("onclick") {
+                if onclick.contains("doDuplicateReceipt") {
+                    receipt_no = extract_receipt_no(onclick);
+                    break;
                 }
-
-                results.push(PaidPaymentReceipt {
-                    receipt_number,
-                    date,
-                    amount,
-                    campus_code,
-                    payment_status: "Paid".to_string(),
-                    receipt_no,
-                });
             }
         }
+        // No download button means this is not a receipt row (totals, notices).
+        if receipt_no.is_empty() {
+            continue;
+        }
+
+        let cell = |i: usize| tds.get(i).map(cell_text).unwrap_or_default();
+
+        results.push(PaidPaymentReceipt {
+            receipt_number: cell(i_receipt),
+            date: cell(i_date),
+            amount: cell(i_amount),
+            campus_code: cell(i_campus),
+            payment_status: "Paid".to_string(),
+            receipt_no,
+        });
     }
 
     results
+}
+
+/// Collapses a cell's text and trims surrounding whitespace.
+fn cell_text(cell: &ElementRef) -> String {
+    cell.text().collect::<String>().trim().to_string()
+}
+
+/// Extracts the id from a `doDuplicateReceipt('78323/27/AMR')` handler.
+fn extract_receipt_no(onclick: &str) -> String {
+    let prefix = "doDuplicateReceipt('";
+    let suffix = "')";
+    if let Some(start) = onclick.find(prefix) {
+        let rest = &onclick[start + prefix.len()..];
+        if let Some(end) = rest.find(suffix) {
+            return rest[..end].to_string();
+        }
+    }
+    String::new()
 }

--- a/rust/src/api/vtop/parser/pending_payments_parser.rs
+++ b/rust/src/api/vtop/parser/pending_payments_parser.rs
@@ -10,6 +10,7 @@ use scraper::{Html, Selector};
 /// # Examples
 ///
 /// ```
+/// # use lib_vtop::api::vtop::parser::pending_payments_parser::parse_pending_payments;
 /// let html = r#"
 /// <table class="table table-bordered table-responsive table-hover">
 ///   <tr>

--- a/rust/src/api/vtop_get_client.rs
+++ b/rust/src/api/vtop_get_client.rs
@@ -314,9 +314,15 @@ pub async fn fetch_grade_history(client: &mut VtopClient) -> Result<GradeHistory
 ///
 /// # Examples
 ///
-/// ```
-/// let payments = student_pending_payments(&mut client).await?;
-/// assert!(!payments.is_empty() || payments.is_empty());
+/// ```no_run
+/// # use lib_vtop::api::vtop::vtop_client::VtopClient;
+/// # use lib_vtop::api::vtop_get_client::fetch_pending_payments;
+/// # async fn example(client: &mut VtopClient) -> Result<(), Box<dyn std::error::Error>> {
+/// // Returns the pending payments serialized as a JSON string.
+/// let payments_json = fetch_pending_payments(client).await?;
+/// println!("{}", payments_json);
+/// # Ok(())
+/// # }
 /// ```
 #[flutter_rust_bridge::frb()]
 pub async fn fetch_pending_payments(client: &mut VtopClient) -> Result<String, VtopError> {

--- a/rust/tests/payment_receipts_parser_test.rs
+++ b/rust/tests/payment_receipts_parser_test.rs
@@ -1,0 +1,89 @@
+use lib_vtop::api::vtop::parser::payment_receipts_parser::parse_payment_receipts;
+
+/// The live VTOP receipts table has 8 columns, with the amount at index 5, the
+/// campus code at index 6, and the view button in the last cell. The parser
+/// used to read amount from index 2 (the invoice number) and campus from index
+/// 3 (the fee group), and looked for the button in index 4, so downloads broke.
+/// This locks in the correct, header-based behaviour.
+#[test]
+fn test_parse_payment_receipts_live_layout() {
+    let html = r#"
+    <table class="table table-bordered">
+      <tr>
+        <th>RECEIPT NUMBER</th><th>DATE</th><th>INVOICE NUMBER</th>
+        <th>FEE GROUP</th><th>FEE SUBGROUP</th><th>AMOUNT</th>
+        <th>CAMPUS CODE</th><th>VIEW</th>
+      </tr>
+      <tr>
+        <td>78323</td><td>08-JUL-2026</td><td>AM2600123276</td>
+        <td>HOSTEL FEE</td><td>Hostelfee_Messfee</td><td>199300.0</td><td>AMR</td>
+        <td><button class="btn btn-warning" onclick="javascript:doDuplicateReceipt('78323/27/AMR');">View</button></td>
+      </tr>
+      <tr>
+        <td>52701</td><td>25-JUN-2026</td><td>AM2600100000</td>
+        <td>TUITION FEE</td><td>Tuition</td><td>8806.0</td><td>AMR</td>
+        <td><button class="btn btn-warning" onclick="javascript:doDuplicateReceipt('52701/27/AMR');">View</button></td>
+      </tr>
+    </table>
+    "#
+    .to_string();
+
+    let receipts = parse_payment_receipts(html);
+
+    assert_eq!(receipts.len(), 2);
+
+    assert_eq!(receipts[0].receipt_number, "78323");
+    assert_eq!(receipts[0].date, "08-JUL-2026");
+    assert_eq!(receipts[0].amount, "199300.0");
+    assert_eq!(receipts[0].campus_code, "AMR");
+    assert_eq!(receipts[0].payment_status, "Paid");
+    assert_eq!(receipts[0].receipt_no, "78323/27/AMR");
+
+    assert_eq!(receipts[1].receipt_number, "52701");
+    assert_eq!(receipts[1].amount, "8806.0");
+    assert_eq!(receipts[1].receipt_no, "52701/27/AMR");
+}
+
+/// A row without a duplicate-receipt button (a totals or empty-state row) must
+/// be skipped, not turned into a bogus receipt.
+#[test]
+fn test_parse_payment_receipts_skips_rows_without_button() {
+    let html = r#"
+    <table class="table table-bordered">
+      <tr>
+        <th>RECEIPT NUMBER</th><th>DATE</th><th>INVOICE NUMBER</th>
+        <th>FEE GROUP</th><th>FEE SUBGROUP</th><th>AMOUNT</th>
+        <th>CAMPUS CODE</th><th>VIEW</th>
+      </tr>
+      <tr>
+        <td></td><td></td><td></td><td></td><td>Total</td><td>199300.0</td><td></td><td></td>
+      </tr>
+    </table>
+    "#
+    .to_string();
+
+    let receipts = parse_payment_receipts(html);
+    assert!(receipts.is_empty());
+}
+
+/// Falls back to the current column positions when the header labels are not
+/// the expected ones, rather than to the old (broken) positions.
+#[test]
+fn test_parse_payment_receipts_positional_fallback() {
+    let html = r#"
+    <table class="table table-bordered">
+      <tr><th>a</th><th>b</th><th>c</th><th>d</th><th>e</th><th>f</th><th>g</th><th>h</th></tr>
+      <tr>
+        <td>78323</td><td>08-JUL-2026</td><td>AM2600123276</td>
+        <td>HOSTEL FEE</td><td>Hostelfee</td><td>199300.0</td><td>AMR</td>
+        <td><button onclick="doDuplicateReceipt('78323/27/AMR');">View</button></td>
+      </tr>
+    </table>
+    "#
+    .to_string();
+
+    let receipts = parse_payment_receipts(html);
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0].amount, "199300.0");
+    assert_eq!(receipts[0].campus_code, "AMR");
+}


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [x] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #48 

## Description

locate columns by **header label** rather than fixed index, and find the receipt button anywhere in the row by its handler(`doDuplicateReceipt('…')`) rather than a fixed cell. Skip rows that have no such button (totals / empty-state rows) instead of erroring. Header-based lookup is more resilient because VTOP has now reordered this table twice.

## Screenshots / Recording

<!-- Required for any UI change. Drag and drop here. Delete this section if not applicable. -->

<!-- Required for any UI change. Drag and drop here. Delete this section if not applicable. -->
<img height="720" alt="Screenshot_20260817_132253" src="https://github.com/user-attachments/assets/2d20aba0-decc-4300-9ee7-688b81b500de" />
<img height="720" alt="Screenshot_20260816_234028" src="https://github.com/user-attachments/assets/bd20821b-f53d-4302-a70c-cfd5df33417e" />

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [ ] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [x] `cargo fmt` run inside `rust/`
- [x] `cargo clippy` passes with no new warnings inside `rust/`
- [x] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [ ] Existing features unaffected by this change
