### PR TITLE
fall back to marks page for semesters when timetable is empty

### DIFF
--- a/rust/src/api/vtop/client/academic.rs
+++ b/rust/src/api/vtop/client/academic.rs
@@ -47,11 +47,46 @@ impl VtopClient {
         if !self.session.is_authenticated() {
             return Err(VtopError::SessionExpired);
         }
-        let url = format!(
-            "{}/vtop/academics/common/StudentTimeTable",
-            self.config.base_url
-        );
 
+        // The semester dropdown appears on several pages, but they are not
+        // equally reliable:
+        //   - The timetable page lists only the semesters the student actually
+        //     has a timetable for. That is the nicest list to show, but it is
+        //     empty for freshers (and others) before their timetable is set up,
+        //     which surfaced as "No semesters available" at login.
+        //   - The marks and exam-schedule pages render the full institutional
+        //     semester list server-side, so their dropdown is populated for
+        //     anyone who can log in, regardless of their own records.
+        //
+        // Try the timetable first for the better list, then fall back to the
+        // fuller pages so login never dead-ends on an empty semester list.
+        const SEMESTER_PAGES: [&str; 3] = [
+            "academics/common/StudentTimeTable",
+            "examinations/StudentMarkView",
+            "examinations/StudExamSchedule",
+        ];
+
+        let mut last = SemesterData {
+            semesters: Vec::new(),
+            update_time: 0,
+        };
+        for page in SEMESTER_PAGES {
+            let data = self.fetch_semesters_from(page).await?;
+            if !data.semesters.is_empty() {
+                return Ok(data);
+            }
+            last = data;
+        }
+
+        // Every source was empty; return the (empty) last result so the caller
+        // can show its "try again later" message rather than an error.
+        Ok(last)
+    }
+
+    /// Loads a VTOP page and parses its `semesterSubId` dropdown into a
+    /// [`SemesterData`]. Used by [`Self::get_semesters`] for each fallback page.
+    async fn fetch_semesters_from(&mut self, page_path: &str) -> VtopResult<SemesterData> {
+        let url = format!("{}/vtop/{}", self.config.base_url, page_path);
         let body = format!(
             "verifyMenu=true&authorizedID={}&_csrf={}&nocache=@(new Date().getTime())",
             self.username,

--- a/rust/tests/semester_parser_test.rs
+++ b/rust/tests/semester_parser_test.rs
@@ -1,0 +1,68 @@
+use lib_vtop::api::vtop::parser::semested_id_parser::parse_semid_from_timetable;
+
+/// Every page get_semesters falls back to (timetable, marks, exam schedule)
+/// exposes the same `select[name="semesterSubId"]` dropdown, led by a
+/// placeholder option. This is the shape the parser must handle.
+fn dropdown(options: &[(&str, &str)]) -> String {
+    let mut html = String::from(
+        r#"<select name="semesterSubId" id="semesterSubId">
+             <option value="">-- Choose Semester --</option>"#,
+    );
+    for (value, name) in options {
+        html.push_str(&format!("<option value=\"{value}\">{name}</option>"));
+    }
+    html.push_str("</select>");
+    html
+}
+
+#[test]
+fn test_parses_semester_dropdown() {
+    let html = dropdown(&[
+        ("AP2026272", "Fall Semester 2026-27"),
+        ("AP2025264", "Winter Semester 2025-26"),
+        ("AP2025262", "Fall Semester 2025-26"),
+    ]);
+
+    let data = parse_semid_from_timetable(html);
+
+    assert_eq!(data.semesters.len(), 3);
+    assert_eq!(data.semesters[0].id, "AP2026272");
+    assert_eq!(data.semesters[0].name, "Fall Semester 2026-27");
+    assert_eq!(data.semesters[1].id, "AP2025264");
+}
+
+/// The fallback source (the marks page) lists the full institutional set of
+/// semesters, so its dropdown parses the same way — this is what makes it a
+/// usable fallback when the timetable dropdown is empty.
+#[test]
+fn test_parses_full_marks_style_dropdown() {
+    let options: Vec<(String, String)> = (0..60)
+        .map(|i| (format!("AP20{:06}", i), format!("Semester {i}")))
+        .collect();
+    let refs: Vec<(&str, &str)> = options
+        .iter()
+        .map(|(v, n)| (v.as_str(), n.as_str()))
+        .collect();
+
+    let data = parse_semid_from_timetable(dropdown(&refs));
+
+    assert_eq!(data.semesters.len(), 60);
+}
+
+/// An empty timetable dropdown (the fresher case) yields no semesters, which is
+/// exactly the signal get_semesters uses to move on to the next fallback page.
+#[test]
+fn test_empty_dropdown_yields_no_semesters() {
+    let html = r#"<select name="semesterSubId" id="semesterSubId">
+                    <option value="">-- Choose Semester --</option>
+                  </select>"#;
+
+    assert!(parse_semid_from_timetable(html.to_string()).semesters.is_empty());
+}
+
+#[test]
+fn test_missing_dropdown_yields_no_semesters() {
+    assert!(parse_semid_from_timetable("<html></html>".to_string())
+        .semesters
+        .is_empty());
+}


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [x] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #9 

## Description

The timetable/attendance dropdowns are filtered to semesters the student has data for — empty for a fresher whose timetable isn't set up. But marks/exam/grade-view list every semester, rendered server-side regardless of the student. So those pages have semesters "for sure,".

## Changes Made

<!-- Bullet-point summary of what changed and where -->

Keep the timetable as primary (its filtered list is the best UX for normal users), and fall back to the marks page when it's empty.

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [ ] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [x] `cargo fmt` run inside `rust/`
- [x] `cargo clippy` passes with no new warnings inside `rust/`
- [x] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [ ] Existing features unaffected by this change
