### PR TITLE
fix: stop orphaning objectbox rows on refresh and logout

### DIFF
--- a/lib/core/providers/current_user.dart
+++ b/lib/core/providers/current_user.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:vit_ap_student_app/core/models/capstone_attendance.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
-import 'package:vit_ap_student_app/core/models/semester_cache.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
+import 'package:vit_ap_student_app/core/providers/user_persistence.dart';
 import 'package:vit_ap_student_app/core/providers/user_preferences_notifier.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
 import 'package:vit_ap_student_app/core/services/demo_service.dart';
@@ -13,33 +12,6 @@ import 'package:vit_ap_student_app/init_dependencies.dart';
 import 'package:vit_ap_student_app/objectbox.g.dart';
 
 part 'current_user.g.dart';
-
-/// Copies freshly fetched data onto the [existing] row already in the box.
-///
-/// Every relation the app refreshes has to be listed here. One left out is not
-/// a compile error — it is silently dropped on every save after the first
-/// login, so the data lives in memory for the session and is gone on restart.
-/// That is exactly what happened to the capstone.
-@visibleForTesting
-void applyRefreshedUser(User existing, User updated) {
-  // ToMany relations are cleared first so a refresh replaces rather than
-  // appends.
-  existing.attendance
-    ..clear()
-    ..addAll(updated.attendance);
-
-  existing.examSchedule
-    ..clear()
-    ..addAll(updated.examSchedule);
-
-  existing.marks
-    ..clear()
-    ..addAll(updated.marks);
-
-  existing.profile.target = updated.profile.target;
-  existing.timetable.target = updated.timetable.target;
-  existing.capstoneAttendance.target = updated.capstoneAttendance.target;
-}
 
 @Riverpod(keepAlive: true)
 class CurrentUserNotifier extends _$CurrentUserNotifier {
@@ -152,10 +124,10 @@ class CurrentUserNotifier extends _$CurrentUserNotifier {
       // For existing users, get the stored version and selectively update
       final existingUser = userBox.get(user.id!);
       if (existingUser != null) {
-        // Replacing a ToOne leaves the old row behind: ObjectBox does not
-        // cascade a delete through one. For the capstone that is a row plus one
-        // per day of the punch calendar, so it is cleared before repointing.
-        _removeCapstone(store, existingUser.capstoneAttendance.target);
+        // Delete what this refresh is about to unlink, while existingUser
+        // still points at it. ObjectBox does not cascade a delete, so anything
+        // skipped here stays in the database unreferenced and forever.
+        removeOrphanedUserData(store, existingUser, user);
 
         applyRefreshedUser(existingUser, user);
 
@@ -168,8 +140,10 @@ class CurrentUserNotifier extends _$CurrentUserNotifier {
         debugPrint('Created new user with ID: $newId');
       }
     } else {
-      // For new users, clear existing data and create fresh
-      userBox.removeAll();
+      // A different account signing in: clear the previous student's rows, not
+      // just their user row, or their data stays on the device alongside the
+      // new account's.
+      removeAllUserData(store);
       final newId = userBox.put(user);
       debugPrint('New user created with ID: $newId');
       // Update state with the new ID
@@ -177,33 +151,9 @@ class CurrentUserNotifier extends _$CurrentUserNotifier {
     }
   }
 
-  /// Deletes a capstone and its punch calendar.
-  ///
-  /// Called before the relation is repointed at freshly fetched data, so the
-  /// unlinked rows do not accumulate one calendar per refresh.
-  void _removeCapstone(Store store, CapstoneAttendance? capstone) {
-    if (capstone == null) return;
-
-    final punchIds = capstone.punches
-        .map((punch) => punch.id)
-        .whereType<int>()
-        .toList();
-    if (punchIds.isNotEmpty) {
-      store.box<CapstonePunch>().removeMany(punchIds);
-    }
-
-    final id = capstone.id;
-    if (id != null) {
-      store.box<CapstoneAttendance>().remove(id);
-    }
-  }
-
   // Manually clear user data
   void _clearUserDataObjectBox() {
-    serviceLocator.get<Store>().box<User>().removeAll();
-
-    // Clear semester cache
-    serviceLocator.get<Store>().box<SemesterCache>().removeAll();
+    removeAllUserData(serviceLocator.get<Store>());
   }
 
   bool get isLoggedIn => state != null;

--- a/lib/core/providers/user_persistence.dart
+++ b/lib/core/providers/user_persistence.dart
@@ -1,0 +1,220 @@
+import 'package:objectbox/objectbox.dart';
+import 'package:vit_ap_student_app/core/models/attendance.dart';
+import 'package:vit_ap_student_app/core/models/capstone_attendance.dart';
+import 'package:vit_ap_student_app/core/models/exam_schedule.dart';
+import 'package:vit_ap_student_app/core/models/grade_history.dart';
+import 'package:vit_ap_student_app/core/models/mark.dart';
+import 'package:vit_ap_student_app/core/models/mentor_details.dart';
+import 'package:vit_ap_student_app/core/models/profile.dart';
+import 'package:vit_ap_student_app/core/models/semester_cache.dart';
+import 'package:vit_ap_student_app/core/models/timetable.dart';
+import 'package:vit_ap_student_app/core/models/user.dart';
+import 'package:vit_ap_student_app/features/home/model/general_outing_report.dart';
+import 'package:vit_ap_student_app/features/home/model/weekend_outing_report.dart';
+
+/// Keeping the stored user row in step with freshly fetched data.
+///
+/// ObjectBox has no cascade delete. Unlinking a relation — `clear()` on a
+/// [ToMany], or repointing a [ToOne] — leaves the rows themselves in the
+/// database, unreferenced and forever. Since every refresh replaces a relation,
+/// the database grew by a whole attendance list, marks list or timetable each
+/// time the student pulled to refresh.
+
+/// The ids a relation is about to orphan: rows it holds now that its
+/// replacement does not.
+///
+/// The subtlety is that only one page's data is refreshed at a time. Every
+/// other relation is passed straight through, still carrying its stored ids,
+/// and those rows have to survive: ObjectBox will not re-insert an object that
+/// already has an id, so deleting them leaves the user pointing at rows that
+/// are gone. Comparing ids rather than object identity is what separates the
+/// two cases — freshly parsed rows have no id yet.
+List<int> orphanedIds(Iterable<int?> current, Iterable<int?> replacement) {
+  final kept = _stored(replacement).toSet();
+  return _stored(current).where((id) => !kept.contains(id)).toList();
+}
+
+/// Ids of rows that are actually in the database. A null or zero id means the
+/// object was parsed from VTOP and has never been stored.
+Iterable<int> _stored(Iterable<int?> ids) =>
+    ids.whereType<int>().where((id) => id != 0);
+
+/// Copies freshly fetched data onto the [existing] row already in the box.
+///
+/// Every relation the app refreshes has to be listed here. One left out is not
+/// a compile error — it is silently dropped on every save after the first
+/// login, so the data lives in memory for the session and is gone on restart.
+void applyRefreshedUser(User existing, User updated) {
+  // ToMany relations are cleared first so a refresh replaces rather than
+  // appends.
+  existing.attendance
+    ..clear()
+    ..addAll(updated.attendance);
+
+  existing.examSchedule
+    ..clear()
+    ..addAll(updated.examSchedule);
+
+  existing.marks
+    ..clear()
+    ..addAll(updated.marks);
+
+  existing.profile.target = updated.profile.target;
+  existing.timetable.target = updated.timetable.target;
+  existing.capstoneAttendance.target = updated.capstoneAttendance.target;
+}
+
+/// Deletes the rows [updated] is about to leave behind.
+///
+/// Call this *before* [applyRefreshedUser], while [existing] still points at
+/// what is currently stored.
+void removeOrphanedUserData(Store store, User existing, User updated) {
+  _removeOrphans<Attendance>(
+    store.box<Attendance>(),
+    existing.attendance,
+    updated.attendance,
+    (row) => row.id,
+  );
+
+  _removeOrphans<ExamSchedule>(
+    store.box<ExamSchedule>(),
+    existing.examSchedule,
+    updated.examSchedule,
+    (row) => row.id,
+    alsoRemove: (exam) => _removeAllOf(
+      store.box<Subject>(),
+      exam.subjects.map((subject) => subject.id),
+    ),
+  );
+
+  _removeOrphans<Mark>(
+    store.box<Mark>(),
+    existing.marks,
+    updated.marks,
+    (row) => row.id,
+    alsoRemove: (mark) => _removeAllOf(
+      store.box<Detail>(),
+      mark.details.map((detail) => detail.id),
+    ),
+  );
+
+  _removeOrphans<Profile>(
+    store.box<Profile>(),
+    _target(existing.profile),
+    _target(updated.profile),
+    (row) => row.id,
+    alsoRemove: (profile) {
+      final gradeHistory = profile.gradeHistory.target;
+      if (gradeHistory != null) {
+        _removeAllOf(
+          store.box<Course>(),
+          gradeHistory.courses.map((course) => course.id),
+        );
+        _removeAllOf(store.box<GradeHistory>(), [gradeHistory.id]);
+      }
+      _removeAllOf(
+        store.box<MentorDetails>(),
+        [profile.mentorDetails.target?.id],
+      );
+    },
+  );
+
+  _removeOrphans<Timetable>(
+    store.box<Timetable>(),
+    _target(existing.timetable),
+    _target(updated.timetable),
+    (row) => row.id,
+    alsoRemove: (timetable) => _removeAllOf(
+      store.box<Day>(),
+      _everyDay(timetable).map((day) => day.id),
+    ),
+  );
+
+  _removeOrphans<CapstoneAttendance>(
+    store.box<CapstoneAttendance>(),
+    _target(existing.capstoneAttendance),
+    _target(updated.capstoneAttendance),
+    (row) => row.id,
+    alsoRemove: (capstone) => _removeAllOf(
+      store.box<CapstonePunch>(),
+      capstone.punches.map((punch) => punch.id),
+    ),
+  );
+}
+
+/// Every row belonging to the signed-in student.
+///
+/// Used on logout and when a different account logs in: without it the previous
+/// student's attendance, marks, timetable and profile stay on the device, and
+/// the next account's data is written alongside them.
+void removeAllUserData(Store store) {
+  store.box<User>().removeAll();
+
+  store.box<Profile>().removeAll();
+  store.box<GradeHistory>().removeAll();
+  store.box<Course>().removeAll();
+  store.box<MentorDetails>().removeAll();
+
+  store.box<Timetable>().removeAll();
+  store.box<Day>().removeAll();
+
+  store.box<Attendance>().removeAll();
+  store.box<CapstoneAttendance>().removeAll();
+  store.box<CapstonePunch>().removeAll();
+
+  store.box<ExamSchedule>().removeAll();
+  store.box<Subject>().removeAll();
+
+  store.box<Mark>().removeAll();
+  store.box<Detail>().removeAll();
+
+  store.box<GeneralOutingReport>().removeAll();
+  store.box<WeekendOutingReport>().removeAll();
+
+  store.box<SemesterCache>().removeAll();
+}
+
+/// A [ToOne] read as a list, so it can go through the same rule as a [ToMany].
+List<T> _target<T>(ToOne<T> relation) {
+  final target = relation.target;
+  return target == null ? const [] : [target];
+}
+
+List<Day> _everyDay(Timetable timetable) => [
+  ...timetable.monday,
+  ...timetable.tuesday,
+  ...timetable.wednesday,
+  ...timetable.thursday,
+  ...timetable.friday,
+  ...timetable.saturday,
+  ...timetable.sunday,
+];
+
+void _removeOrphans<T>(
+  Box<T> box,
+  Iterable<T> current,
+  Iterable<T> replacement,
+  int? Function(T row) idOf, {
+  void Function(T orphan)? alsoRemove,
+}) {
+  final orphans = orphanedIds(
+    current.map(idOf),
+    replacement.map(idOf),
+  ).toSet();
+  if (orphans.isEmpty) return;
+
+  // Children first: once the parent row is gone there is nothing left to read
+  // the child ids from.
+  if (alsoRemove != null) {
+    for (final row in current) {
+      if (orphans.contains(idOf(row))) alsoRemove(row);
+    }
+  }
+
+  box.removeMany(orphans.toList());
+}
+
+void _removeAllOf<T>(Box<T> box, Iterable<int?> ids) {
+  final stored = _stored(ids).toList();
+  if (stored.isNotEmpty) box.removeMany(stored);
+}

--- a/lib/features/account/view/pages/account_page.dart
+++ b/lib/features/account/view/pages/account_page.dart
@@ -6,6 +6,7 @@ import 'package:vit_ap_student_app/core/common/widget/styled_sheet.dart';
 import 'package:vit_ap_student_app/core/constants/analytics_constants.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/providers/schedule_home_widget_notifier.dart';
 import 'package:vit_ap_student_app/core/providers/user_preferences_notifier.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
 import 'package:vit_ap_student_app/core/services/app_upgrader.dart';
@@ -352,6 +353,15 @@ class _AccountPageState extends ConsumerState<AccountPage> {
                         destructive: true,
                       );
                       if (!confirmed || !context.mounted) return;
+
+                      // The home screen widget keeps its own copy of the
+                      // timetable, outside ObjectBox. Left alone it carries on
+                      // showing this student's classes after they sign out.
+                      final homeWidget = ref.read(
+                        scheduleHomeWidgetProvider.notifier,
+                      );
+                      await homeWidget.clearTimetable();
+                      await homeWidget.updateWidget();
 
                       await ref.read(currentUserProvider.notifier).logout();
                       if (!context.mounted) return;

--- a/test/core/providers/orphaned_rows_test.dart
+++ b/test/core/providers/orphaned_rows_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vit_ap_student_app/core/providers/user_persistence.dart';
+
+void main() {
+  group('orphanedIds', () {
+    /// The leak this fixes: ObjectBox unlinks on clear() but never deletes, so
+    /// every refresh left the whole previous list in the database.
+    test('a refresh with all new rows orphans everything it replaces', () {
+      // Rows parsed from VTOP have no id until they are put.
+      expect(orphanedIds([1, 2, 3], [null, null, null]), [1, 2, 3]);
+    });
+
+    /// The reason this cannot just delete whatever was there. Refreshing one
+    /// page passes every other relation through untouched, still carrying its
+    /// stored ids. ObjectBox will not re-insert an object that already has an
+    /// id, so deleting those rows leaves the user pointing at nothing.
+    test('rows passed straight through are kept', () {
+      expect(orphanedIds([1, 2, 3], [1, 2, 3]), isEmpty);
+    });
+
+    test('keeps what survives and drops only what does not', () {
+      expect(orphanedIds([1, 2, 3], [2, null]), [1, 3]);
+    });
+
+    test('an empty replacement orphans everything', () {
+      expect(orphanedIds([1, 2], []), [1, 2]);
+    });
+
+    test('nothing stored means nothing to orphan', () {
+      expect(orphanedIds([], [1, 2]), isEmpty);
+      expect(orphanedIds([null, null], [null]), isEmpty);
+    });
+
+    test('treats a zero id as unstored, the same as null', () {
+      // ObjectBox uses 0 for "not put yet"; json_serializable leaves it null.
+      // Neither is a row that can be deleted.
+      expect(orphanedIds([0, 1], [0]), [1]);
+      expect(orphanedIds([0], []), isEmpty);
+    });
+
+    test('ignores ordering', () {
+      expect(orphanedIds([1, 2, 3], [3, 1]), [2]);
+    });
+
+    test('a repointed relation orphans the row it left', () {
+      // A ToOne is read as a one-element list, so it goes through the same rule.
+      expect(orphanedIds([4], [null]), [4]);
+      expect(orphanedIds([4], [4]), isEmpty);
+      expect(orphanedIds([4], []), [4]);
+    });
+  });
+}

--- a/test/core/providers/user_refresh_test.dart
+++ b/test/core/providers/user_refresh_test.dart
@@ -7,7 +7,7 @@ import 'package:vit_ap_student_app/core/models/mark.dart';
 import 'package:vit_ap_student_app/core/models/profile.dart';
 import 'package:vit_ap_student_app/core/models/timetable.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
-import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/providers/user_persistence.dart';
 
 Attendance attendance(String courseCode) => Attendance(
       classNumber: '1',


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Follow-up to #62.

## Description

ObjectBox has no cascade delete. Unlinking a relation — `clear()` on a `ToMany`, or
repointing a `ToOne` — leaves the rows themselves in the database, unreferenced and
forever.

Every refresh replaces a relation, so the database has been growing by a whole
attendance list, marks list or timetable every time anyone pulls to refresh. Logging out
removed only the `User` row, leaving every attendance record, mark, timetable, profile
and outing report behind on the device.

**This also fixes a bug introduced in #62.** The capstone cleanup added there deletes the
old capstone row unconditionally. Refreshing any *other* page passes the capstone through
untouched, still carrying its stored id — and ObjectBox will not re-insert an object that
already has an id, so the row was deleted and never written back. Refreshing marks, the
timetable, the exam schedule or the account page silently destroyed a stored capstone;
the tab then disappeared until the next attendance refresh. That is on `main` now.

## Changes Made

- New `user_persistence.dart` holding the rule and the graph walk, out of the provider.
- `orphanedIds(current, replacement)` — the rows a relation is about to leave behind.
  Comparing ids rather than object identity is the whole point: freshly parsed rows have
  no id yet, so they are recognisably new, while a relation passed straight through
  still carries its stored ids and has to survive.
- `removeOrphanedUserData` walks what a user owns and deletes only the orphans, children
  first: attendance, exam schedule and its subjects, marks and their details, the profile
  with its grade history, courses and mentor details, the timetable with all seven days,
  and the capstone with its punch calendar.
- `removeAllUserData` clears every one of those boxes, plus outing reports and the
  semester cache. Used on logout and when a different account signs in — the second path
  previously called `userBox.removeAll()` only, so a new account's data was written
  alongside the previous student's.
- Logout now clears the home screen widget. `clearTimetable()` already existed and was
  never called, so the widget kept showing the previous student's classes after sign-out.

## Screenshots / Recording

Not applicable — no UI change.

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [x] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

No Rust changes.

### Testing

- [ ] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [x] Existing features unaffected by this change

### Schema

No schema change. No new entities, no new properties — only deletes that were already
supposed to be happening.
